### PR TITLE
Remove ghp-import from handbook requirements.txt

### DIFF
--- a/handbook/requirements.txt
+++ b/handbook/requirements.txt
@@ -1,4 +1,3 @@
 jupyter-book
 matplotlib
 numpy
-ghp-import


### PR DESCRIPTION
Not required as we are deploying the book using a different methodology