### PR TITLE
Use a modern version of the checkout action

### DIFF
--- a/.github/workflows/deploy_handbook.yml
+++ b/.github/workflows/deploy_handbook.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Install dependencies
       - name: Set up Python v3.10


### PR DESCRIPTION
v2 used node12 which is deprecated. v4 should use node16+ which is supported. This may be why the publish to gh-pages steps was always being skipped.