### PR TITLE
Bump to a modern version of the setup-python version

### DIFF
--- a/.github/workflows/deploy_handbook.yml
+++ b/.github/workflows/deploy_handbook.yml
@@ -28,7 +28,7 @@ jobs:
 
       # Install dependencies
       - name: Set up Python v3.10
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Install dependencies


### PR DESCRIPTION
v1 used node12 which is now deprected. v4 uses a supported version of node.