### PR TITLE
Simplify repo2docker workflow

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -8,11 +8,6 @@ on:
       - main
     paths:
       - "images/**"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "images/**"
 
 # When multiple PRs triggering this workflow are merged, queue them instead
 # of running them in parallel in case of clashes when pushing
@@ -64,8 +59,6 @@ jobs:
       matrix:
         jobs: ${{ fromJson(needs.generate-build-matrix.outputs.images-to-build) }}
     steps:
-      - run: echo "${{ github.event_name == 'pull_request' }}"
-
       # For biggish images, github actions runs out of disk space.
       # So we cleanup some unwanted things in the disk image, and reclaim that space for our docker use
       # https://github.com/actions/virtual-environments/issues/2606#issuecomment-772683150
@@ -98,11 +91,7 @@ jobs:
           # Tell repo2docker which subdirectory to examine
           # ref: https://repo2docker.readthedocs.io/en/latest/usage.html#cmdoption-jupyter-repo2docker-subdir
           REPO2DOCKER_EXTRA_ARGS: "--subdir images/${{ matrix.jobs.image-name }}"
-  
-          # If the event that triggered this workflow was a pull request, the image
-          # will be built but not pushed to the registry
-          NO_PUSH: ${{ github.event_name == 'pull_request' }}
-  
+
       # Lets us monitor disks getting full as images get bigger over time
       - name: Show how much disk space is left
         run: df -h

--- a/images/test-image/requirements.txt
+++ b/images/test-image/requirements.txt
@@ -1,3 +1,0 @@
-numpy
-pandas
-matplotlib


### PR DESCRIPTION
We had some issues with the workflow, notably that `NO_PUSH` wasn't ingesting the github conditional correctly and seemingly preventing pushing.

This PR simplifies the workflow to just run after merge for now. I'll do some further debugging to see if I can bring back the build-but-no-push-from-a-pr functionality without resorting to a second workflow file