### PR TITLE
Add scripts/workflows that will comment the image name and tag of an image that was built and pushed by repo2docker

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,3 +1,5 @@
+# If changing this name, you MUST also update the trigger in comment-built-images-to-pr.yaml
+# https://github.com/2i2c-org/community-showcase/blob/HEAD/.github/workflows/comment-built-images-to-pr.yaml#L1
 name: Build and push container images
 
 # Trigger this workflow on pushes to main branches under the images folder or

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -50,8 +50,9 @@ jobs:
         run: |
           python scripts/generate-image-build-matrix-jobs.py "${{ steps.changed-files.outputs.changed_files }}"
 
-  # This job will build the images identified by the previous job and optionally
-  # push them to container registry
+  # This job will build the images identified by the previous job and
+  # push them to container registry. We also upload an artifact containing the
+  # built image name to be used in another workflow for better discoverability.
   build-and-push:
     runs-on: ubuntu-latest
     needs: [generate-build-matrix]
@@ -73,6 +74,7 @@ jobs:
         uses: actions/checkout@v4
   
       - name: Build and conditionally push the image to quay.io
+        id: r2d-build
         uses: jupyterhub/repo2docker-action@master
         with:
           # Make sure username & password/token pair matches your registry credentials
@@ -95,3 +97,15 @@ jobs:
       # Lets us monitor disks getting full as images get bigger over time
       - name: Show how much disk space is left
         run: df -h
+
+      # Write the image name and tag to a file
+      - name: Write the image name and tag to a file
+        run: |
+          echo "${{ steps.r2d-build.outputs.IMAGE_SHA_NAME }}" > image-name.txt
+
+      # Upload file containing image name and tag as an artifact
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: "${{ matrix.jobs.image-name }}-image-name"
+          path: image-name.txt

--- a/.github/workflows/comment-built-images-to-pr.yaml
+++ b/.github/workflows/comment-built-images-to-pr.yaml
@@ -1,0 +1,25 @@
+name: Comment built image names and tags to a PR
+
+on:
+  workflow_run:
+    workflows:
+      # This MUST match the 'name:' field of the target workflow
+      # https://github.com/2i2c-org/community-showcase/blob/HEAD/.github/workflows/build-images.yaml#L3
+      - "Build and push container images"
+    types:
+      - completed
+
+jobs:
+  comment-built-images-to-pr:
+    runs-on: ubuntu-latest
+    # Grant GITHUB_TOKEN enough permissions to read information about GitHub
+    # Actions and comment on PRs
+    permissions:
+      actions: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: python scripts/comment-image-name-to-pr.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_RUN: ${{ github.event.workflow_run }}

--- a/scripts/comment-image-name-to-pr.py
+++ b/scripts/comment-image-name-to-pr.py
@@ -1,0 +1,103 @@
+"""
+This script is a helper script to improve the discoverability of image names and
+tags pushed to a registry by our build-images workflow.
+
+It takes the following actions:
+- Establishes which PR created the changes by extracting the number from the
+  head commit message
+- Downloads all artifacts associcated with a previous workflow run
+- Extracts the contents of each artifact and composes them into a comment body
+- Posts the comment body to the PR that was merged and built the images
+"""
+import io
+import os
+import re
+import sys
+import json
+import requests
+import zipfile
+from textwrap import dedent
+
+api_url = "https://api.github.com"
+
+# GITHUB_TOKEN = ${{ secrets.GITHUB_TOKEN }} in workflow file
+token = os.environ.get("GITHUB_TOKEN", None)
+if token is None:
+    raise ValueError("GITHUB_TOKEN must be set!")
+
+# WORKFLOW_RUN = ${{ github.event.workflow_run }} in workflow file
+workflow_run = os.environ.get("WORKFLOW_RUN", None)
+if workflow_run is None:
+    raise ValueError("WORKFLOW_RUN must be set!")
+workflow_run = json.loads(workflow_run)
+
+# Set headers to send with requests
+headers = {
+    "Accept": "application/vnd.github+json",
+    "Authorization": f"Bearer {token}",
+}
+
+# Use regex to extract the PR number from the commit message
+match = re.search("(?<=#)[0-9]*", workflow_run["head_commit"]["message"])
+pr_number = None if match is None else match.group(0)
+
+# Check if 'Merge pull request' appears in the commit message. Continue execution
+# if it DOES.
+if "Merge pull request" not in workflow_run["head_commit"]["message"]:
+    sys.exit()
+
+# List all artifacts for the workflow run
+resp = requests.get(
+    workflow_run["artifacts_url"], headers=headers, params={"per_page": 100}
+)
+all_artifacts = resp.json()["artifacts"]
+
+# If "Link" is present in the response headers, that means that the results are
+# paginated and we need to loop through them to collect all the results.
+# It is unlikely that we will have more than 100 artifact results for a single
+# worflow ID however.
+while ("Link" in resp.headers.keys()) and ('rel="next"' in res.headers["Link"]
+):
+    next_url = re.search(r'(?<=<)([\S]*)(?=>; rel="next")', resp.headers["Link"])
+    resp = requests.get(next_url.group(0), headers=headers)
+    all_artifacts.extend(resp.json()["artifacts"])
+
+# Filter for the artifact with the name we want: ending in '-image-name'
+filtered_artifacts = [
+    i
+    for i, artifact in enumerate(all_artifacts)
+    if artifact["name"].endswith("-image-name")
+]
+
+if len(filtered_artifacts) == 0:
+    print(f"No artifacts found ending with '-image-name' for workflow run: {run_id}")
+    sys.exit()
+
+# Empty list to store artifact contents in
+artifact_contents = []
+
+# Download the artifacts
+for artifact in filtered_artifacts:
+    resp = requests.get(
+        all_artifacts[artifact]["archive_download_url"],
+        headers=headers,
+        stream=True
+    )
+
+    # Extract the zip archive
+    with zipfile.ZipFile(io.BytesIO(resp.content)) as zip_ref:
+        zip_ref.extractall(os.getcwd())
+
+    # Read in file
+    with open(f"name.txt") as f:
+        artifact_contents.append(f.read().strip("\n"))
+
+artifact_contents = "\n- ".join(artifact_contents)
+
+# Comment artifact content to merged PR
+comment = dedent(f"""Pushed images and tags:
+
+- {artifact_contents}""")
+
+url = "/".join([api_url, "repos", workflow_run["repository"]["full_name"], "issues", pr_number, "comments"])
+requests.post(url, headers=headers, json={"body": comment})


### PR DESCRIPTION
- related: https://github.com/2i2c-org/community-showcase/issues/25#issuecomment-1830299308

In this PR:

- build-images.yaml updated to output the image name and tag of built-and-pushed images to a txt file that is uploaded as a GitHub Actions artifact
- Added a Python that handles logic around:
  - Establishing which PR merge triggered a run of build-images.yaml workflow
  - Downloading the artifacts created by build-images.yaml
  - Aggregating the contents of these artifacts into a comment
  - Posting that comment to the relevant PR
- Add the comment-built-images-to-pr.yaml workflow which executes the above mentioned Python script upon successful completion of the build-images.yaml workflow