### PR TITLE
Pin docutils version

### DIFF
--- a/images/handbook-authoring-image/requirements.txt
+++ b/images/handbook-authoring-image/requirements.txt
@@ -6,4 +6,5 @@ jupyterlab-iframe
 jupyterlab-git 
 jupyterlab_myst
 jupyter-server-proxy
+docutils==0.17.1
 gh-scoped-creds


### PR DESCRIPTION
Need to downgrade `docutils` to `v0.17.1` for the rendering with the bibliography block to work (see related [GH issue](https://github.com/executablebooks/jupyter-book/issues/2022)). Upgrading `docutils` to `v0.20.1` doesn't work for now as this results in dependency hell for `myst-parser`, `sphinx` and `jupyter-book`.