### PR TITLE
Fix the filename that the script reads to match what is set in the build-images workflow file

### DIFF
--- a/scripts/comment-image-name-to-pr.py
+++ b/scripts/comment-image-name-to-pr.py
@@ -89,7 +89,7 @@ for artifact in filtered_artifacts:
         zip_ref.extractall(os.getcwd())
 
     # Read in file
-    with open(f"name.txt") as f:
+    with open(f"image-name.txt") as f:
         artifact_contents.append(f.read().strip("\n"))
 
 artifact_contents = "\n- ".join(artifact_contents)


### PR DESCRIPTION
This should be the final fix for #51 